### PR TITLE
Read resource dict value null

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -1,3 +1,3 @@
 name: vyos
-version: 1.0.3
+version: 1.0.4.dev1589714556
 license: ASL2.0

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -215,6 +215,10 @@ class VyosHandler(VyosBaseHandler):
 
     def _dict_to_path(self, node, dct):
         paths = []
+
+        if dct is None:
+            return paths
+
         if isinstance(dct, str):
             paths.append((node, dct))
             return paths


### PR DESCRIPTION
Performing a dryrun where the current configuration dict contains a `None` value resulted in a failure because of the call `dct.items()`.