### PR TITLE
Issue/29 ubiquiti save configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.3.3
+- Allow slightly different configuration save confirmation message for ubiquiti devices (#29)
+
 # V1.3.2
 - Use inmanta-dev-dependencies package
 

--- a/module.yml
+++ b/module.yml
@@ -1,3 +1,3 @@
 name: vyos
-version: 1.3.2
+version: 1.3.3.dev1605349933
 license: ASL2.0

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -211,7 +211,10 @@ class VyosHandler(VyosBaseHandler):
             return cache[resource.device]
         out = vyos.configure()
         out = vyos.run_conf_mode_command("save /tmp/inmanta_tmp")
-        if "Saving configuration to '/tmp/inmanta_tmp'" not in out:
+        if not (
+            "Saving configuration to '/tmp/inmanta_tmp'" in out
+            or "saving configuration to non-default location '/tmp/inmanta_tmp'" in out
+        ):
             raise SkipResource(f"Could not save config: {out}")
         ctx.debug("Saved config: %(out)s", out=out)
         out = vyos.exit()


### PR DESCRIPTION
# Description

Ubiquiti devices have a slightly different configuration save confirmation message. This PR allows that message.

closes #29

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
