### PR TITLE
fix VLAN ID constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# V2.0.1
+- Fix VLAN ID type constraint
+
 # V2.0.0
 - Change bridge config from bridge-group to members for vyos>1.2.6
 

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -18,6 +18,7 @@ vyos_12 = std::OS(family=vyos, name="vyos", version=1.2)
 typedef area as number matching self >= 0 and self < 4294967296
 typedef duplex as string matching self == "auto" or self == "half" or self == "full"
 typedef speed as string matching self in ["10", "100", "1000", "2500","10000", "auto"]
+typedef vlan_id as int matching self > 0 and self < 4095
 
 # General Framework
 entity ConfigItem:
@@ -320,7 +321,7 @@ implement Tunnel using parents, tunnel
 Vif.parent [1] -- Interface
 
 entity Vif extends BaseInterface:
-    net::vlan_id vlan
+    vlan_id vlan
     string type="vif"
     string name=""
 end

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -18,7 +18,7 @@ vyos_12 = std::OS(family=vyos, name="vyos", version=1.2)
 typedef area as number matching self >= 0 and self < 4294967296
 typedef duplex as string matching self == "auto" or self == "half" or self == "full"
 typedef speed as string matching self in ["10", "100", "1000", "2500","10000", "auto"]
-typedef vlan_id as int matching self > 0 and self < 4095
+typedef vlan_id as int matching self >= 0 and self < 4095
 
 # General Framework
 entity ConfigItem:

--- a/module.yml
+++ b/module.yml
@@ -1,3 +1,3 @@
 name: vyos
-version: 2.0.0
+version: 2.0.1
 license: ASL2.0

--- a/module.yml
+++ b/module.yml
@@ -1,3 +1,3 @@
 name: vyos
-version: 2.0.1
+version: 2.0.1.dev1655712646
 license: ASL2.0


### PR DESCRIPTION
# Description

fixes the VLAN ID constraint issue we faced. VyOS only accepts ranges from 0 to 4094