### PR TITLE
Convert requirements.txt file to new constraint format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
-# V3.0.0
+# Changelog
 
 ## v3.0.4 - ?
 
 - Convert constraints in requirements.txt file
-
-
 - Added `null` defaults to nullable attributes. These attributes can now only be set in the constructor.
+
 # V2.0.1
 - Fix VLAN ID type constraint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.0.4 - ?
 
+- Convert constraints in requirements.txt file
 
 
 - Added `null` defaults to nullable attributes. These attributes can now only be set in the constructor.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-vyattaconfparser==0.5.5
-vymgmt==0.1
+vyattaconfparser>=0.5,<1
+vymgmt>=0.1,<1
 
-pexpect==4.8.0
-ptyprocess==0.7.0
+pexpect>=4.8,<5
+ptyprocess>=0.7,<1


### PR DESCRIPTION
# Description

Convert requirements.txt file from `~=` format to `>=X,<Y` format.

Part of inmanta/infra-tickets#181

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
